### PR TITLE
Include Hamcrest without clashing with PHPUnit globals

### DIFF
--- a/tests/ExternalLinksTest.php
+++ b/tests/ExternalLinksTest.php
@@ -1,7 +1,5 @@
 <?php
 
-if (class_exists('Phockito')) Phockito::include_hamcrest();
-
 class ExternalLinksTest extends SapphireTest {
 
 	protected static $fixture_file = 'ExternalLinksTest.yml';
@@ -9,6 +7,14 @@ class ExternalLinksTest extends SapphireTest {
 	protected $extraDataObjects = array(
 		'ExternalLinksTest_Page'
 	);
+
+	public function setUpOnce() {
+		if (class_exists('Phockito')) {
+			Phockito::include_hamcrest(false);
+		}
+
+		parent::setUpOnce();
+	}
 
 	public function setUp() {
 		parent::setUp();
@@ -60,7 +66,7 @@ class ExternalLinksTest extends SapphireTest {
 			->return(null);
 
 		Phockito::when($checker)
-			->checkLink(anything()) // anything else is 404
+			->checkLink(Hamcrest_Matchers::anything()) // anything else is 404
 			->return(404);
 
 		Injector::inst()->registerService($checker, 'LinkChecker');


### PR DESCRIPTION
PHPUnit had a Functions.php with global methods like any() for a while (3.7 at least),
which clashes with similar globals from Hamcrest (used in Phockito).

Both PHPUnit and Phockito use 'classmap' composer autoloading,
but that's not directly requiring/evaluating the files.
The problem is caused by SilverStripe's ClassLoader
which does require ALL subclasses of SapphireTest.
This in turn causes PHP outside of the class context to execute,
which includes Hamcrest.

Changing the include_hamcrest() is not strictly necessary here,
but makes the code a bit more resilient against any preceding
test including Functions.php from PHPUnit.

See https://github.com/hafriedlander/phockito/issues/32 for context.