### PR TITLE
Allow to configure CurlLinkChecker request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ You can set them with the following config in config.yml.
 # Headers
 SilverStripe\ExternalLinks\Tasks\CurlLinkChecker:
   headers:
-    user-agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0"
-    accept-encoding: "gzip, deflate, br"
-    referer: "https://www.domain.com/"
-    sec-fetch-mode: "navigate"
+    - 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0'
+    - 'accept-encoding: gzip, deflate, br'
+    - 'referer: https://www.domain.com/'
+    - 'sec-fetch-mode: navigate'
     ...
 ```

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ You can set them with the following config in config.yml.
 ```yaml
 # Headers
 SilverStripe\ExternalLinks\Tasks\CurlLinkChecker:
-  user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0"
   headers:
-    - "accept-encoding: gzip, deflate, br"
-    - "referer: https://www.domain.com/"
-    - "sec-fetch-mode: navigate"
+    user-agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0"
+    accept-encoding: "gzip, deflate, br"
+    referer: "https://www.domain.com/"
+    sec-fetch-mode: "navigate"
     ...
 ```

--- a/README.md
+++ b/README.md
@@ -110,3 +110,19 @@ following config in config.yml.
 SilverStripe\ExternalLinks\Tasks\CurlLinkChecker::
   bypass_cache: 1
 ```
+
+## Headers
+
+You may want to set headers to be sent with the CURL request (eg: user-agent) to avoid website rejecting the request thinking it is a bot.
+You can set them with the following config in config.yml.
+
+```yaml
+# Headers
+SilverStripe\ExternalLinks\Tasks\CurlLinkChecker:
+  user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) Gecko/20100101 Firefox/53.0"
+  headers:
+    - "accept-encoding: gzip, deflate, br"
+    - "referer: https://www.domain.com/"
+    - "sec-fetch-mode: navigate"
+    ...
+```

--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -34,7 +34,7 @@ class CurlLinkChecker implements LinkChecker
     /**
      * Allow to pass custom header to be in CURL request
      * 
-     * * @config
+     * @config
      * @var array
      */
      private static $headers = [];

--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -32,21 +32,11 @@ class CurlLinkChecker implements LinkChecker
     private static $bypass_cache = false;
 
     /**
-     * Set default user agent as config
-     * Override via YAML file
-     * 
-     * * @config
-     * @var string
-     */
-    private static $user_agent = '';
-
-    /**
      * Allow to pass custom header to be in CURL request
      * 
      * * @config
      * @var array
      */
-
      private static $headers = [];
 
     /**
@@ -90,20 +80,14 @@ class CurlLinkChecker implements LinkChecker
             curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
         }
 
-        // Add user agent
-        $userAgent = trim($this->config()->get('user_agent'));
-        if ($userAgent) {
-            curl_setopt($handle, CURLOPT_USERAGENT , $userAgent);
-        }
-
-        // Other headers
-        if ($headers = $this->config()->get('headers')) {
-            if (is_array($headers)) {
-                 curl_setopt($handle, CURLOPT_HTTPHEADER , $headers);
-            } else {
-                 curl_setopt($handle, CURLOPT_HTTPHEADER , array($headers));
-            }
-        }
+        // Add headers
+        $headers = (array) $this->config()->get('headers');
+        if (!empty($headers)) {
+            array_walk($headers, function(&$value, $header) {
+                $value = "$header: $value";
+            });
+            curl_setopt($handle, CURLOPT_HTTPHEADER , $headers); 
+        }        
         
         // Retrieve http code
         curl_exec($handle);

--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -33,11 +33,11 @@ class CurlLinkChecker implements LinkChecker
 
     /**
      * Allow to pass custom header to be in CURL request
-     * 
+     *
      * @config
      * @var array
      */
-     private static $headers = [];
+    private static $headers = [];
 
     /**
      * Return cache
@@ -83,11 +83,11 @@ class CurlLinkChecker implements LinkChecker
         // Add headers
         $headers = (array) $this->config()->get('headers');
         if (!empty($headers)) {
-            array_walk($headers, function(&$value, $header) {
+            array_walk($headers, function (&$value, $header) {
                 $value = "$header: $value";
             });
-            curl_setopt($handle, CURLOPT_HTTPHEADER , $headers); 
-        }        
+            curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
+        }
         
         // Retrieve http code
         curl_exec($handle);

--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -32,6 +32,24 @@ class CurlLinkChecker implements LinkChecker
     private static $bypass_cache = false;
 
     /**
+     * Set default user agent as config
+     * Override via YAML file
+     * 
+     * * @config
+     * @var string
+     */
+    private static $user_agent = '';
+
+    /**
+     * Allow to pass custom header to be in CURL request
+     * 
+     * * @config
+     * @var array
+     */
+
+     private static $headers = [];
+
+    /**
      * Return cache
      *
      * @return CacheInterface
@@ -66,11 +84,28 @@ class CurlLinkChecker implements LinkChecker
         // No cached result so just request
         $handle = curl_init($href);
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($handle, CURLOPT_TIMEOUT, 10);
         if ($this->config()->get('follow_location')) {
             curl_setopt($handle, CURLOPT_FOLLOWLOCATION, true);
         }
-        curl_setopt($handle, CURLOPT_CONNECTTIMEOUT, 5);
-        curl_setopt($handle, CURLOPT_TIMEOUT, 10);
+
+        // Add user agent
+        $userAgent = trim($this->config()->get('user_agent'));
+        if ($userAgent) {
+            curl_setopt($handle, CURLOPT_USERAGENT , $userAgent);
+        }
+
+        // Other headers
+        if ($headers = $this->config()->get('headers')) {
+            if (is_array($headers)) {
+                 curl_setopt($handle, CURLOPT_HTTPHEADER , $headers);
+            } else {
+                 curl_setopt($handle, CURLOPT_HTTPHEADER , array($headers));
+            }
+        }
+        
+        // Retrieve http code
         curl_exec($handle);
         $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
         curl_close($handle);
@@ -79,6 +114,7 @@ class CurlLinkChecker implements LinkChecker
             // Cache result
             $this->getCache()->set($cacheKey, $httpCode);
         }
+
         return $httpCode;
     }
 }

--- a/src/Tasks/CurlLinkChecker.php
+++ b/src/Tasks/CurlLinkChecker.php
@@ -83,12 +83,9 @@ class CurlLinkChecker implements LinkChecker
         // Add headers
         $headers = (array) $this->config()->get('headers');
         if (!empty($headers)) {
-            array_walk($headers, function (&$value, $header) {
-                $value = "$header: $value";
-            });
             curl_setopt($handle, CURLOPT_HTTPHEADER, $headers);
         }
-        
+
         // Retrieve http code
         curl_exec($handle);
         $httpCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
This gives the ability to set a user agent and other request headers to be used by the CurlLinkChecker task.