### PR TITLE
ENH Restrict access to getJobStatus execution

### DIFF
--- a/client/javascript/BrokenExternalLinksReport.js
+++ b/client/javascript/BrokenExternalLinksReport.js
@@ -17,6 +17,7 @@
       },
 
       start: function() {
+        var self = this;
         // initiate a new job
         $('.external-links-report__report-progress')
           .empty()
@@ -25,10 +26,14 @@
         $.ajax({
           url: "admin/externallinks/start",
           async: true,
-          timeout: 3000
+          timeout: 3000,
+          success: function() {
+            self.poll();
+          },
+          error: function() {
+            self.buttonReset();
+          }
         });
-
-        this.poll();
       },
 
       /**
@@ -125,10 +130,7 @@
               $('.external-links-report__create-report').poll();
             }, 1000));
           },
-          error: function(e) {
-            if (typeof console !== 'undefined') {
-              console.log(e);
-            }
+          error: function() {
             self.buttonReset();
           }
         });

--- a/src/Controllers/CMSExternalLinksController.php
+++ b/src/Controllers/CMSExternalLinksController.php
@@ -8,6 +8,7 @@ use SilverStripe\ExternalLinks\Tasks\CheckExternalLinksTask;
 use SilverStripe\Control\Controller;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
 use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
+use SilverStripe\Security\Permission;
 
 class CMSExternalLinksController extends Controller
 {
@@ -24,6 +25,9 @@ class CMSExternalLinksController extends Controller
      */
     public function getJobStatus()
     {
+        if (!Permission::check('CMS_ACCESS_CMSMain')) {
+            return $this->httpError(403, 'You do not have permission to access this resource');
+        }
         // Set headers
         HTTPCacheControlMiddleware::singleton()->setMaxAge(0);
         $this->response
@@ -49,6 +53,9 @@ class CMSExternalLinksController extends Controller
      */
     public function start()
     {
+        if (!Permission::check('CMS_ACCESS_CMSMain')) {
+            return $this->httpError(403, 'You do not have permission to access this resource');
+        }
         // return if the a job is already running
         $status = BrokenExternalPageTrackStatus::get_latest();
         if ($status && $status->Status == 'Running') {


### PR DESCRIPTION
## Description
- Added verification of user access to the CMS and limited the ability to execute a request to `getJobStatus` and `start`.
- Added error handling on the client.

## Parent issue
- https://github.com/silverstripe/silverstripe-externallinks/issues/112 